### PR TITLE
Remove `this.get` / `this.set`.

### DIFF
--- a/addon/index.js
+++ b/addon/index.js
@@ -1,4 +1,5 @@
 import Ember from 'ember';
+
 export default class {
   constructor() {
     Ember.meta(this); 
@@ -10,13 +11,5 @@ export default class {
   
   static extend() {
     throw new Error('please use ES6 class syntax for subclassing this object');
-  }
-
-  get(key) {
-    return Ember.get(this, key);
-  }
-
-  set(key) {
-    return Ember.set(this, key);
   }
 }


### PR DESCRIPTION
When using decorators (for CP support) `this.get` / `Ember.get` is not needed (we setup valid normal getters in Ember 3.1)...

@stefanpenner - Thoughts?