### PR TITLE
Remove manual `Ember.meta` "slotting".

### DIFF
--- a/addon/index.js
+++ b/addon/index.js
@@ -1,4 +1,3 @@
-import Ember from 'ember';
 export default class {
   static create(attrs) {
     return new this(attrs);

--- a/addon/index.js
+++ b/addon/index.js
@@ -1,9 +1,5 @@
 import Ember from 'ember';
 export default class {
-  constructor() {
-    Ember.meta(this); 
-  }
-    
   static create(attrs) {
     return new this(attrs);
   } 


### PR DESCRIPTION
Ember 2.x _sometimes_ added a property to the object itself (later versions of Ember 2.x series used `WeakMap` when available to avoid this). As of Ember 3.x Ember no longer supports the fallback path for `Ember.meta` which would add a property to the underlying object (and therefore cause shaping issues). 

_tldr;_ this code is no longer needed :wink: